### PR TITLE
Rewrote visitor

### DIFF
--- a/examples/apiOptions.js
+++ b/examples/apiOptions.js
@@ -1,0 +1,27 @@
+const fs = require('fs')
+const path = require('path')
+const transformConfig = require('..')
+
+const code = fs.readFileSync(path.join(process.cwd(), 'examples/configs/nuxt.simple.js'), 'utf8')
+
+const mod = ["@nuxtjs/prismic", {
+  "endpoint": "https://prismic.prismic.io",
+  apiOptions: {
+    "routes": ["/:uid", "/"]
+  }
+}]
+
+const args = {
+  css: ['path/to/file'],
+  modules: [mod],
+  script: ['/script-key-created'],
+  transpile: ['my-other-module'],
+}
+
+const {
+  code: updated
+} = transformConfig(code, 'nuxt', args)
+
+console.log('previous code:\n', code)
+
+console.log('new code:\n', updated)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "babel-transform-config",
+  "name": "@prismicio/babel-transform-config",
   "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
@@ -1021,6 +1021,16 @@
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
     "loose-envify": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "@babel/standalone": "^7.8.8",
     "@babel/template": "^7.8.6",
     "@babel/traverse": "^7.8.6",
-    "consola": "^2.11.3"
+    "consola": "^2.11.3",
+    "lodash.isequal": "^4.5.0",
+    "lodash.sortby": "^4.7.0"
   }
 }

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -1,14 +1,21 @@
 const consola = require('consola')
 const toAst = require('./toAst')
 
-const {
-  dedupeStringLiterals,
-  testNodeValue,
-  buildSubjacentPaths
-} = require('./utils')
+const { dedupe } = require('./utils')
 
 const OPERATIONS = ['create', 'merge', 'replace', 'delete']
 
+function getParentPropertyName(path) {
+  if (path.parent.type === 'ExportDefaultDeclaration') {
+    return "__default"
+  } else if (path.parent.key) {
+    return (path.parent.key.value || path.parent.key.name)
+  }
+}
+
+function accessorKey(type) {
+  return type === 'ArrayExpression' ? 'elements' : 'properties'
+}
 function mergePaths(parentKeys, nodeName) {
   return `${parentKeys}${parentKeys.length ? ':' : ''}${nodeName}`
 }
@@ -32,8 +39,8 @@ function validateAction(transform) {
   }
 }
 
-function validateTransforms(transforms) {
-  Object.entries(transforms).forEach(([key, transform]) => {
+function formatTransforms(transforms) {
+  return Object.entries(transforms).reduce((acc, [key, transform]) => {
     if (!transform.action || !transform.action.length) {
       throw new Error(`Transformation with key "${key}" should possess a non-empty "action" key`)
     }
@@ -41,85 +48,65 @@ function validateTransforms(transforms) {
       throw new Error(`Transformation with key "${key}" should possess a non-empty "value" key`)
     }
     validateAction(transform)
-  })
+    return {
+      ...acc,
+      [`__default:${key}`]: transform
+    }
+  }, {})
 }
 
-module.exports = function({ types: t }, transforms) {
-  const status = {}
+module.exports = function ({ types: t }, transformsProps) {
+  const transforms = formatTransforms(transformsProps)
 
-  validateTransforms(transforms)
-  Object.keys(transforms).forEach((key) => status[key] = false)
-
-
-  const expressionVisitor = {
-    ObjectExpression(path, { isRoot, objectKeysPath, createKey, value }) {
-
-      const fullPathToBuild = mergePaths(objectKeysPath, createKey)
-      const currentParentKey = path.parent.key ? path.parent.key.name : ''
-
-      const currentPathToBuild = mergePaths(currentParentKey, createKey)
-
-      if (currentPathToBuild === fullPathToBuild) {
-        if (
-          path.parent.declaration
-          && path.parent.declaration.properties
-          && path.parent.declaration.properties.find(e => e.key.name === createKey)
-        ) {
-          return
-        }
-
-        // Make sure you create root key
-        // at exportDefault level to prevent writing value evrywhere
-        if (isRoot && (!path.parentPath.node.key || path.parentPath.node.key.loc)) {
-          return
-        }
-        const newObjectProperty = t.ObjectProperty(
-          t.identifier(createKey),
-          toAst(t, value)
-        )
-        path.node.properties = [
-          ...path.node.properties,
-          newObjectProperty
-        ]
-      }
-    }
-  }
   const objectPropVisitor = {
-    ObjectProperty(path, { parentKeys = '' } =  {}) {
-      const currentPath = mergePaths(parentKeys, path.node.key.name)
-      const transform = transforms[currentPath]
-
-      if (transform && !status[currentPath]) {
-        status[currentPath] = true
-        const operations = transform.action.split(':')
-        if (operations.includes('delete')) {
-          return path.remove()
-        }
-
-        const { type } = path.node.value
-        const elemExists = testNodeValue(t, path);
-
-        (function handleWrite() {
-          if ((!elemExists && operations.includes('create')) || operations.includes('replace')) {
-            path.node.value = toAst(t, transform.value)
-          }
-
-          else if (operations.includes('merge')) {
-            const accessor = type === 'ArrayExpression' ? 'elements' : 'properties'
-            const elems = [
-              ...path.node.value[accessor],
-              ...toAst(t, transform.value)[accessor]
-            ];
-            path.node.value[accessor] = dedupeStringLiterals(elems)
-          }
-        })();
+    ObjectExpression(path, { nest = '' } = {}) {
+      const currentKey = getParentPropertyName(path)
+      if (!currentKey) {
+        return
       }
+      const currentPath = mergePaths(nest, currentKey)
 
-      if (path.node.value && (path.node.value.properties || path.node.value.elements)) {
-        return path.traverse(objectPropVisitor, {
-          parentKeys: currentPath
+      const maybeTransforms =
+        Object.entries(transforms).filter(([key]) =>
+          key.split(':').slice(0, -1).join(':') === currentPath
+        )
+
+      if (maybeTransforms.length) {
+        maybeTransforms.forEach(([key, transform]) => {
+          if (transform) {
+            const operations = transform.action.split(':')
+            if (operations.includes('delete')) {
+              return path.remove()
+            }
+
+            const maybeProperty =
+              path.node.properties.find(e => (e.key.value || e.key.name) === key.split(':').pop())
+
+            const shouldCreate = !maybeProperty && operations.includes('create')
+
+            if (shouldCreate || operations.includes('replace')) {
+              const accessor = accessorKey(path.node)
+              const elems = [
+                ...path.node[accessor],
+                t.objectProperty(t.Identifier(key.split(':').pop()), toAst(t, transform.value))
+              ]
+              return path.node[accessor] = dedupe(elems, key.name)
+            }
+
+            if (operations.includes('merge')) {
+              const accessor = accessorKey(maybeProperty.value.type)
+              const elems = [
+                ...maybeProperty.value[accessor],
+                ...toAst(t, transform.value)[accessor]
+              ];
+              maybeProperty.value[accessor] = dedupe(elems, key.name)
+            }
+          }
         })
       }
+      return path.traverse(objectPropVisitor, {
+        nest: currentPath
+      })
     }
   }
 
@@ -137,27 +124,6 @@ module.exports = function({ types: t }, transforms) {
           return consola.error('Could not find default exported object. Maybe your config file returns a function?')
         }
         exportPath.traverse(objectPropVisitor)
-
-        Object.entries(status).forEach(([key, value]) => {
-          if (value === false && transforms[key].action.indexOf('create') !== -1) {
-            const subPaths = key.split(':')
-            const subPathsToCreate = buildSubjacentPaths(subPaths).slice(0, -1);
-
-            subPathsToCreate.forEach((p, i) => {
-              exportPath.traverse(expressionVisitor, {
-                objectKeysPath: p.slice(0, -1).join(':'),
-                createKey: p.pop(),
-                value: {},
-                isRoot: i === 0
-              })
-            })
-            exportPath.traverse(expressionVisitor, {
-              objectKeysPath: key.split(':').slice(0, -1).join(':'),
-              createKey: key.split(':').pop(),
-              value: transforms[key].value
-            })
-          }
-        }, [])
       },
     }
   }

--- a/plugin/utils.js
+++ b/plugin/utils.js
@@ -1,9 +1,90 @@
-function buildSubjacentPaths(arr, store = [], len = 0) {
-  if (len >= arr.length) {
-    return store
-  }
-  store = [...store, arr.slice(0, len + 1)]
-  return buildSubjacentPaths(arr, store, len + 1)
+const isEqual = require('lodash.isequal')
+const sortBy = require("lodash.sortby");
+
+function dedupeModulesLike(modules) {
+  const moduleNames = {}
+  return modules.filter((elem) => {
+    if (elem.type === 'StringLiteral') {
+      if (moduleNames[elem.value]) {
+        return false
+      }
+      moduleNames[elem.value] = true
+      return true
+    }
+    if (elem.type === 'ArrayExpression') {
+      const maybeModName = elem.elements[0]
+      if (
+        !maybeModName ||
+        maybeModName.type !== 'StringLiteral' ||
+        !maybeModName.value
+      ) {
+        return true // don't eval
+      }
+      if (moduleNames[maybeModName.value]) {
+        return false
+      }
+      moduleNames[maybeModName.value] = true
+      return true
+    }
+  })
+}
+
+/** 
+ * 
+ * type: 'ObjectProperty',
+   key: {
+     type: 'StringLiteral',
+     value: 'src'
+   },
+   value: {
+     type: 'StringLiteral',
+     value: 'duped'
+   },
+   computed: false,
+   shorthand: false,
+   decorators: null
+ */
+function dedupeObjectExpressions(objectProperties, keyName) {
+  const propertiesList = objectProperties
+    .map(({
+      properties
+    }) => ([
+      ...properties.map(({
+        type,
+        key,
+        value,
+        computed,
+        shorthand,
+        decorator
+      }) => ({
+        type,
+        key: key.value || key.name,
+        value: value.value,
+        computed,
+        shorthand,
+        decorator
+      }))
+    ]))
+
+  const dedupedProps = propertiesList.reduce((acc, properties, index) => {
+    // sort current property and flatten it
+    // for each (flattened) elem in acc, test equality
+    // return true if 1 was true
+    const duplicate = acc.find((accProps, iii) => {
+      const sortedProps = sortBy(properties.map(sortBy)).flat()
+      const sortedAcc = sortBy(accProps.map(sortBy)).flat()
+      const isEq = isEqual(sortedProps, sortedAcc)
+      return isEq
+    });
+
+    if (duplicate) {
+      console.log("duplicate", duplicate);
+      return acc
+    }
+    return [...acc, properties]
+
+  }, [])
+  return dedupedProps
 }
 
 function dedupeStringLiterals(elements) {
@@ -18,23 +99,37 @@ function dedupeStringLiterals(elements) {
   })
 }
 
-/** There probably is a better way */
-function testNodeValue(t, path) {
-  const { type } = path.node.value
-  if (type === 'ArrayExpression') {
-    return !!path.node.value.elements.length
+function dedupe(elements, keyName) {
+  const elementTypes = elements.map(({
+    type
+  }) => type)
+  const ofSingleType = elementTypes.every(val => val === elementTypes[0])
+  const childrenType = ofSingleType ? elementTypes[0] : null
+
+  const isArrayAndOrString = !ofSingleType &
+    elementTypes.every(val =>
+      val === 'StringLiteral' ||
+      val === 'ArrayExpression'
+    )
+
+  if (ofSingleType) {
+    if (childrenType === 'StringLiteral') {
+      return dedupeStringLiterals(elements)
+    }
+    if (childrenType === 'ObjectExpression') {
+      const duplicateKeys = dedupeObjectExpressions(elements, keyName)
+    }
   }
-  if (type === 'ObjectExpression') {
-    return !!path.node.value.properties.length
+
+  if (isArrayAndOrString) {
+    return dedupeModulesLike(elements)
   }
-  if (type === 'NullLiteral') {
-    return false
-  }
-  return true
+
+  return elements
+
 }
 
 module.exports = {
-  buildSubjacentPaths,
   dedupeStringLiterals,
-  testNodeValue
+  dedupe
 }


### PR DESCRIPTION
As the process of updating/creating keys was super obscure and subject to errors (mainly loosing track of nested keys), I tried to merge both update and create visitors into one.

It's clearer, more concise and works with the examples folder.

I also added an example for `apiOptions`

Run `node examples/apiOptions.js` to validate